### PR TITLE
disable the default critical and high findings for guardduty

### DIFF
--- a/rules/aws_guardduty_rules/aws_guardduty_critical_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_critical_sev_findings.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: aws_guardduty_critical_sev_findings.py
 RuleID: "AWS.GuardDuty.CriticalSeverityFinding"
 DisplayName: "AWS GuardDuty Critical Severity Finding"
-Enabled: true
+Enabled: false
 LogTypes:
   - AWS.GuardDuty
 Tags:

--- a/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
+++ b/rules/aws_guardduty_rules/aws_guardduty_high_sev_findings.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: aws_guardduty_high_sev_findings.py
 RuleID: "AWS.GuardDuty.HighSeverityFinding"
 DisplayName: "AWS GuardDuty High Severity Finding"
-Enabled: true
+Enabled: false
 LogTypes:
   - AWS.GuardDuty
 Tags:


### PR DESCRIPTION
### Background

Disable the default guardduty defaults as we have the filtered versions for the bitcoin / crypto miners

### Changes

Disable the rules

### Testing

None needed, disabling rule
