### PR TITLE
disable this rule due to high rate of FP's and security already has a…

### DIFF
--- a/rules/sigma_rules/okta_password_in_alternateid_field.yml
+++ b/rules/sigma_rules/okta_password_in_alternateid_field.yml
@@ -12,7 +12,7 @@ Description: 'Detects when a user has potentially entered their password into th
 
   False Positives: Unlikely'
 DisplayName: Potential Okta Password in AlternateID Field
-Enabled: true
+Enabled: false
 Filename: okta_password_in_alternateid_field.py
 LogTypes:
 - Okta.SystemLog


### PR DESCRIPTION


### Background

There is an extremely high level of noise w/ this rule. Most are attempted auths to internal services.

### Changes

- Disabling rule

### Testing

- not needed
